### PR TITLE
Recommend wimp_BUTTON_WRITABLE for writable icons

### DIFF
--- a/Chapters/ch15-icons-indirect.xml
+++ b/Chapters/ch15-icons-indirect.xml
@@ -171,11 +171,11 @@ static char win_icon_text[WIN_ICON_TEXT_LEN];</code>
 <code lang="c">icon_definition.icon.flags = wimp_ICON_TEXT | wimp_ICON_INDIRECTED |
 		wimp_ICON_BORDER | wimp_ICON_FILLED |
 		wimp_ICON_HCENTRED | wimp_ICON_VCENTRED |
-		(wimp_BUTTON_WRITE_CLICK_DRAG &lt;&lt; wimp_ICON_BUTTON_TYPE_SHIFT) |
+		(wimp_BUTTON_WRITABLE &lt;&lt; wimp_ICON_BUTTON_TYPE_SHIFT) |
 		(wimp_COLOUR_BLACK &lt;&lt; wimp_ICON_FG_COLOUR_SHIFT) |
 		(wimp_COLOUR_WHITE &lt;&lt; wimp_ICON_BG_COLOUR_SHIFT);</code>
 
-<p>Setting the button type is done in a very similar way to setting the colours: the required value is shifted into position using the constants defined by OSLib. We&rsquo;re using <name>wimp_BUTTON_WRITE_CLICK_DRAG</name> instead of <name>wimp_BUTTON_WRITABLE</name> because the latter is largely obsolete. The modified code can be found in <reference id="dl-icons-indirect-writable"/>.</p>
+<p>Setting the button type is done in a very similar way to setting the colours: the required value is shifted into position using the constants defined by OSLib.The modified code can be found in <reference id="dl-icons-indirect-writable"/>.</p>
 
 <download id="dl-icons-indirect-writable" file="WritableIcon" title="Creating a Writable Icon" compatibility="none"/>
 

--- a/Chapters/ch16-interact-click.xml
+++ b/Chapters/ch16-interact-click.xml
@@ -141,7 +141,7 @@ typedef struct os_coord os_coord;</code>
 
 <section>
 <title>Getting more reaction</title>
-<p>The question is why the window only responds to <mouse>Menu</mouse> clicks? The answer is that when we set up the window&rsquo;s work area flags in <reference id="sect-window-theory-loose-ends"/>, we set them to <name>wimp_BUTTON_NEVER</name>; similarly, the icon&rsquo;s button type was also set to <name>wimp_BUTTON_NEVER</name> (after a short flirtation with <name>wimp_BUTTON_WRITE_CLICK_DRAG</name>) in <reference id="sect-icons-indirect-behaviour"/>. This button type ignores mouse clicks, and never reports them to our application.</p>
+<p>The question is why the window only responds to <mouse>Menu</mouse> clicks? The answer is that when we set up the window&rsquo;s work area flags in <reference id="sect-window-theory-loose-ends"/>, we set them to <name>wimp_BUTTON_NEVER</name>; similarly, the icon&rsquo;s button type was also set to <name>wimp_BUTTON_NEVER</name> (after a short flirtation with <name>wimp_BUTTON_WRITABLE</name>) in <reference id="sect-icons-indirect-behaviour"/>. This button type ignores mouse clicks, and never reports them to our application.</p>
 
 <p>At least, that&rsquo;s <em>almost</em> true. Due to the standard use of the <mouse>Menu</mouse> button for opening context menus on RISC&nbsp;OS, the Wimp will always pass <mouse>Menu</mouse> clicks through to the application, regardless of the object under the pointer. That&rsquo;s why <mouse>Menu</mouse> clicks are being reported: there&rsquo;s no way to switch them off.</p>
 

--- a/Chapters/ch27-icons-writable.xml
+++ b/Chapters/ch27-icons-writable.xml
@@ -58,7 +58,9 @@
 
 <image id="fig-icons-writable-zap" file="icons-writable-zap.png" title="An application can hide the caret if it wishes to"/>
 
-<p>An application can handle the incoming keypresses itself, inserting characters, performing edits and moving the caret as required. This will be the approach taken by software such as wordprocessors and text editors, but it can involve a fair bit of work. An easier approach, and the one that we will start by looking at here, is to hand the problem back to the Wimp by using a writable icon: one with a type of <name>wimp_BUTTON_WRITE_CLICK_DRAG</name> or <name>wimp_BUTTON_WRITABLE</name>. An example can be seen in <reference id="fig-icons-writable-icon"/>.</p>
+<p>An application can handle the incoming keypresses itself, inserting characters, performing edits and moving the caret as required. This will be the approach taken by software such as wordprocessors and text editors, but it can involve a fair bit of work. An easier approach, and the one that we will start by looking at here, is to hand the problem back to the Wimp by using a writable icon: one with a type of <name>wimp_BUTTON_WRITABLE</name>. An example can be seen in <reference id="fig-icons-writable-icon"/>.</p>
+
+<p>An icon of type <name>wimp_BUTTON_WRITE_CLICK_DRAG</name> is a special variant of the writable icon, which reports drag events to the task. Wimp-handled drags within the icon (such as for text selection) may not work with icons of type <name>wimp_BUTTON_WRITE_CLICK_DRAG</name>, so in most cases <name>wimp_BUTTON_WRITABLE</name> is recommended.</p>
 
 <image id="fig-icons-writable-icon" file="icons-writable-icon.png" title="In a writable icon, the Wimp handles the caret for us"/>
 

--- a/Downloads/Chapter15/FilteredWritableIcon/c/win
+++ b/Downloads/Chapter15/FilteredWritableIcon/c/win
@@ -113,7 +113,7 @@ static wimp_i win_create_icon(void)
 	icon_definition.icon.flags = wimp_ICON_TEXT | wimp_ICON_INDIRECTED |
 			wimp_ICON_BORDER | wimp_ICON_FILLED |
 			wimp_ICON_HCENTRED | wimp_ICON_VCENTRED |
-			(wimp_BUTTON_WRITE_CLICK_DRAG << wimp_ICON_BUTTON_TYPE_SHIFT) |
+			(wimp_BUTTON_WRITABLE << wimp_ICON_BUTTON_TYPE_SHIFT) |
 			(wimp_COLOUR_BLACK << wimp_ICON_FG_COLOUR_SHIFT) |
 			(wimp_COLOUR_WHITE << wimp_ICON_BG_COLOUR_SHIFT);
 

--- a/Downloads/Chapter15/WritableIcon/c/win
+++ b/Downloads/Chapter15/WritableIcon/c/win
@@ -113,7 +113,7 @@ static wimp_i win_create_icon(void)
 	icon_definition.icon.flags = wimp_ICON_TEXT | wimp_ICON_INDIRECTED |
 			wimp_ICON_BORDER | wimp_ICON_FILLED |
 			wimp_ICON_HCENTRED | wimp_ICON_VCENTRED |
-			(wimp_BUTTON_WRITE_CLICK_DRAG << wimp_ICON_BUTTON_TYPE_SHIFT) |
+			(wimp_BUTTON_WRITABLE << wimp_ICON_BUTTON_TYPE_SHIFT) |
 			(wimp_COLOUR_BLACK << wimp_ICON_FG_COLOUR_SHIFT) |
 			(wimp_COLOUR_WHITE << wimp_ICON_BG_COLOUR_SHIFT);
 


### PR DESCRIPTION
Previously `wimp_BUTTON_WRITE_CLICK_DRAG` was promoted over `wimp_BUTTON_WRITABLE`. However, `wimp_BUTTON_WRITABLE` is more desirable.

On RISC OS 5 `wimp_BUTTON_WRITE_CLICK_DRAG` does not support text selection.

See the [Drag-And-Drop Functional Specification](https://www.riscosopen.org/wiki/documentation/show/Drag-And-Drop%20Functional%20Specification#TOC4.1.3.9).